### PR TITLE
Fixed closing h1 tag

### DIFF
--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div class="container">
-      <h1>Welcome to Flask!</h2>
+      <h1>Welcome to Flask!</h1>
       <br>
       <p>Click <a href="/">here</a> to go home.</p>
     </div>


### PR DESCRIPTION
When i copied the html from your repo, vscode highlighted a problem with the html with this message `Tag must be paired, missing: [ </h1> ], start tag match failed [ <h1> ]` hence the fix.